### PR TITLE
differentiate between exceptions

### DIFF
--- a/api_postcode_nl.gemspec
+++ b/api_postcode_nl.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
     "api_postcode_nl.gemspec",
     "lib/api_postcode_nl.rb",
     "lib/api_postcode_nl/api.rb",
-    "lib/api_postcode_nl/invalid_postcode_exception.rb",
+    "lib/api_postcode_nl/exceptions.rb",
     "test/helper.rb",
     "test/test_api_postcode_nl.rb"
   ]

--- a/lib/api_postcode_nl/exceptions.rb
+++ b/lib/api_postcode_nl/exceptions.rb
@@ -1,0 +1,6 @@
+module ApiPostcodeNl
+  class InvalidPostcodeException < Exception; end
+  class InvalidHouseNumberException < InvalidPostcodeException; end
+  class AddressNotFoundException < InvalidPostcodeException; end
+  class PostcodeTooLongException < InvalidPostcodeException; end
+end

--- a/lib/api_postcode_nl/invalid_postcode_exception.rb
+++ b/lib/api_postcode_nl/invalid_postcode_exception.rb
@@ -1,5 +1,0 @@
-module ApiPostcodeNl
-  class InvalidPostcodeException < Exception
-  
-  end
-end


### PR DESCRIPTION
There are now exceptions for "Invalid house number", "Postcode too
long" and "Address not found", all extending from
`InvalidPostcodeException` for BC
